### PR TITLE
Let's talk before about level 8 and 9

### DIFF
--- a/check_process
+++ b/check_process
@@ -28,8 +28,8 @@
 	Level 5=auto
 	Level 6=auto
 	Level 7=auto
-	Level 8=1
-	Level 9=1
+#	Level 8=1
+#	Level 9=1
 	Level 10=0
 ;;; Options
 Email=ljf+ynh-strut@grimaud.me


### PR DESCRIPTION
First, as an official app, It's better to not commit directly your modifications, without any reviews.

And to reach these level, above 7, because we can't have any automatic check, you have to ask for a validation of the apps group. And, by the way, keep a record of this agree.

Also, even if your app as no reason to not works on any other architecture, we do not have so far any test on x86-32. So I think we should wait for these test before according a level 8 to any app.

And most of all, I not really agree with this tricky  and sneaky method to pass through the linter with your source origin...
https://github.com/YunoHost-Apps/strut_ynh/blob/master/conf/app.src#L1 and https://github.com/YunoHost-Apps/strut_ynh/tree/ebd1e859cb1ecc0cc3166969fc1db649f3ddb61c/sources
I know the situation, but, I really prefer to keep this source code clearly visible and accessible.